### PR TITLE
Fix NullAway compilation errors with JSpecify annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <optional>true</optional>
@@ -76,6 +80,23 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>am.ik.maven</groupId>
+        <artifactId>nullability-maven-plugin</artifactId>
+        <version>0.2.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <checking>tests</checking>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>configure</goal>
+              <goal>generate-package-info</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/am/ik/spring/logbook/AccessLoggerLogbookAutoConfiguration.java
+++ b/src/main/java/am/ik/spring/logbook/AccessLoggerLogbookAutoConfiguration.java
@@ -1,5 +1,6 @@
 package am.ik.spring.logbook;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -44,7 +45,7 @@ public class AccessLoggerLogbookAutoConfiguration {
 	static class AccessLoggerHints implements RuntimeHintsRegistrar {
 
 		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+		public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 			if (ClassUtils.isPresent(JAKARTA_SERVLET_HTTP_HTTP_SERVLET_REQUEST, classLoader)) {
 				hints.reflection()
 					.registerType(TypeReference.of(JAKARTA_SERVLET_HTTP_HTTP_SERVLET_REQUEST),

--- a/src/main/java/am/ik/spring/logbook/AccessLoggerSink.java
+++ b/src/main/java/am/ik/spring/logbook/AccessLoggerSink.java
@@ -1,6 +1,7 @@
 package am.ik.spring.logbook;
 
 import java.io.IOException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
@@ -95,7 +96,7 @@ public class AccessLoggerSink implements Sink {
 		loggingEventBuilder.log(messageBuilder.toString());
 	}
 
-	protected String getUsername(HttpRequest request) {
+	protected @Nullable String getUsername(HttpRequest request) {
 		return null;
 	}
 

--- a/src/main/java/am/ik/spring/logbook/ServletAwareAccessLoggerSink.java
+++ b/src/main/java/am/ik/spring/logbook/ServletAwareAccessLoggerSink.java
@@ -1,13 +1,14 @@
 package am.ik.spring.logbook;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
 import org.zalando.logbook.ForwardingHttpRequest;
 import org.zalando.logbook.HttpRequest;
 
 public class ServletAwareAccessLoggerSink extends AccessLoggerSink {
 
 	@Override
-	protected String getUsername(HttpRequest request) {
+	protected @Nullable String getUsername(HttpRequest request) {
 		if (request instanceof HttpServletRequest httpServletRequest) {
 			return httpServletRequest.getRemoteUser();
 		}

--- a/src/test/java/org/zalando/logbook/servlet/ServletAwareAccessLoggerSinkTest.java
+++ b/src/test/java/org/zalando/logbook/servlet/ServletAwareAccessLoggerSinkTest.java
@@ -20,7 +20,7 @@ class ServletAwareAccessLoggerSinkTest {
 	Correlation correlation = new Correlation() {
 		@Override
 		public Instant getEnd() {
-			return null;
+			return Instant.now();
 		}
 
 		@Override
@@ -35,7 +35,7 @@ class ServletAwareAccessLoggerSinkTest {
 
 		@Override
 		public Instant getStart() {
-			return null;
+			return Instant.now();
 		}
 	};
 


### PR DESCRIPTION
## Summary
- Add `@Nullable` annotations to fix NullAway compilation errors in `AccessLoggerLogbookAutoConfiguration`, `AccessLoggerSink`, and `ServletAwareAccessLoggerSink`
- Fix test code returning `null` for `@NonNull` methods (`getEnd()`, `getStart()`) by returning `Instant.now()` instead

## Test plan
- [x] `./mvnw clean test` passes (7 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)